### PR TITLE
feat: add Parameter ID Object syntax to TNGL

### DIFF
--- a/Spectoda.ts
+++ b/Spectoda.ts
@@ -2538,9 +2538,10 @@ export class Spectoda implements SpectodaClass {
   readVariableAddress(variable_address: number, id: SpectodaTypes.ID = 255) {
     logging.debug("> Reading variable address...");
 
-    if (this.#getConnectionState() !== "connected") {
-      throw "DeviceDisconnected";
-    }
+    const memory_stack = this.#parser.getMemoryStack();
+    logging.verbose(`memory_stack=${memory_stack}`);
+
+    logging.info(`Reading memory address ${variable_address} for ID${id} with description: "${memory_stack[variable_address]}" ...`);
 
     return this.runtime.readVariableAddress(variable_address, id);
   }

--- a/src/SpectodaRuntime.ts
+++ b/src/SpectodaRuntime.ts
@@ -433,7 +433,7 @@ export class SpectodaRuntime {
           name: this.WIP_name,
         },
         console: {
-          debug: 4,
+          debug: logging.level,
         },
         io: {
           DUMMY: {

--- a/src/SpectodaWasm.ts
+++ b/src/SpectodaWasm.ts
@@ -3,7 +3,7 @@
 import { logging } from "../logging";
 import { MainModule, Uint8Vector } from "./types/wasm";
 
-const WASM_VERSION = "DEBUG_DEV_0.12.2_20241216";
+const WASM_VERSION = "DEBUG_DEV_0.12.3_20241218";
 
 let moduleInitilizing = false;
 let moduleInitilized = false;

--- a/src/types/wasm.ts
+++ b/src/types/wasm.ts
@@ -1,7 +1,7 @@
-/// === auto-generated from Emscripten build process === ///
-/// ========== DEBUG_DEV_0.12.0_20241116.d.ts ========== ///
-
 import { Event } from "./event";
+
+/// === auto-generated from Emscripten build process === ///
+/// ========== DEBUG_DEV_0.12.3_20241218.d.ts ========== ///
 
 export interface interface_error_tValue<T extends number> {
   value: T;
@@ -184,7 +184,7 @@ export interface MainModule {
   ImplementedSpectoda_WASM: {};
 }
 
-/// ========== DEBUG_DEV_0.12.0_20241116.d.ts ========== ///
+/// ========== DEBUG_DEV_0.12.3_20241218.d.ts ========== ///
 
 /// =================== MANUALLY DEFINED INTERFACES ================= ///
 


### PR DESCRIPTION
Adds `{ ID255: 10%, ID1: 1% }` syntax functionality to define constant values for each ID separatelly for Sunflow DVN parameter definition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced new methods for parsing and compiling TNGL code, enhancing variable declaration handling.
	- Updated logging capabilities for better debugging insights.

- **Bug Fixes**
	- Improved error handling and control flow in variable address reading.

- **Chores**
	- Updated WebAssembly version to reflect the latest build.
	- Refined type definitions and organization in the WASM type file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->