### PR TITLE
refactor: event names

### DIFF
--- a/Spectoda.ts
+++ b/Spectoda.ts
@@ -17,9 +17,9 @@ import "./TnglWriter";
 import { ConnectionStatus } from "./deprecated_store/types";
 import { SpectodaRuntime, allEventsEmitter } from "./src/SpectodaRuntime";
 import { VALUE_LIMITS, VALUE_TYPE } from "./src/constants";
+import { SpectodaAppEventMap, SpectodaAppEventName as SpectodaJsEventType } from "./src/types/app-events";
 import { CONNECTION_STATUS, ConnectorType, WEBSOCKET_CONNECTION_STATE, WebsocketConnectionState } from "./src/types/connect";
-import { Event } from "./src/types/event";
-import { SpectodaJsEventMap, SpectodaJsEventName as SpectodaJsEventType } from "./src/types/spectoda-js-events";
+import { SpectodaEvent } from "./src/types/event";
 import { SpectodaTypes } from "./src/types/primitives";
 import { SpectodaClass } from "./src/types/spectodaClass";
 import { fetchTnglFromApiById, sendTnglToApi } from "./tnglapi";
@@ -574,14 +574,14 @@ export class Spectoda implements SpectodaClass {
    * TODO I think this should expose an "off" method to remove the listener
    * @returns {Function} unbind function
    */
-  addEventListener<K extends keyof SpectodaJsEventMap>(event: K, callback: (props: SpectodaJsEventMap[K]) => void) {
+  addEventListener<K extends keyof SpectodaAppEventMap>(event: K, callback: (props: SpectodaAppEventMap[K]) => void) {
     return this.runtime.addEventListener(event, callback);
   }
 
   /**
    * @alias this.addEventListener
    */
-  on<K extends keyof SpectodaJsEventMap>(event: K, callback: (props: SpectodaJsEventMap[K]) => void) {
+  on<K extends keyof SpectodaAppEventMap>(event: K, callback: (props: SpectodaAppEventMap[K]) => void) {
     return this.runtime.on(event, callback);
   }
 
@@ -2876,7 +2876,7 @@ export class Spectoda implements SpectodaClass {
       this.#__events[id] = {};
     }
 
-    const unregisterListenerEmittedevents = this.runtime.on("emittedevents", (events: Event[]) => {
+    const unregisterListenerEmittedevents = this.runtime.on("emittedevents", (events: SpectodaEvent[]) => {
       for (const event of events) {
         if (event.id === 255) {
           for (let id = 0; id < 256; id++) {
@@ -2939,7 +2939,7 @@ export class Spectoda implements SpectodaClass {
       });
   }
 
-  emitEvents(events: Event[] | { label: SpectodaTypes.Label; type: string | SpectodaTypes.ValueType; value: null | string | number | boolean; id: SpectodaTypes.ID; timestamp: number }[]) {
+  emitEvents(events: SpectodaEvent[] | { label: SpectodaTypes.Label; type: string | SpectodaTypes.ValueType; value: null | string | number | boolean; id: SpectodaTypes.ID; timestamp: number }[]) {
     logging.verbose("emitEvents(events=", events, ")");
 
     logging.info("> Emitting events...");

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,8 @@
-export * from "./functions";
-export * from "./logging";
 export * from "./Spectoda";
 export * from "./deprecated_store/index";
-export * from "./src/types/spectoda-js-events";
+export * from "./functions";
+export * from "./logging";
+export * from "./src/types/app-events";
 export type * from "./types";
 
 export { mockScanResult } from "./__mocks__/scan";

--- a/src/SpectodaRuntime.ts
+++ b/src/SpectodaRuntime.ts
@@ -24,9 +24,8 @@ import { TimeTrack } from "../TimeTrack";
 import { PreviewController } from "./PreviewController";
 import { SpectodaWasm } from "./SpectodaWasm";
 import { Spectoda_JS } from "./Spectoda_JS";
-import { COMMAND_FLAGS } from "./constants";
-import { APP_MAC_ADDRESS, DEFAULT_TIMEOUT } from "./constants";
 import { SpectodaConnectConnector } from "./connector/SpectodaConnectConnector";
+import { APP_MAC_ADDRESS, COMMAND_FLAGS, DEFAULT_TIMEOUT } from "./constants";
 
 import { Spectoda } from "../Spectoda";
 import { TnglReader } from "../TnglReader";
@@ -34,12 +33,11 @@ import { TnglWriter } from "../TnglWriter";
 import { SpectodaNodeBluetoothConnector } from "./connector/SpectodaNodeBleConnector";
 import { SpectodaNodeSerialConnector } from "./connector/SpectodaNodeSerialConnector";
 import { SpectodaSimulatedConnector } from "./connector/SpectodaSimulatedConnector";
-import { SpectodaTypes } from "./types/primitives";
-import { Synchronization } from "./types/wasm";
-import { Connection } from "./types/wasm";
-import { EventStateValue } from "./types/event";
-import { SpectodaJsEventMap, SpectodaJsEventName } from "./types/spectoda-js-events";
+import { SpectodaAppEventMap } from "./types/app-events";
 import { ConnectorType } from "./types/connect";
+import { SpectodaEventStateValue } from "./types/event";
+import { SpectodaTypes } from "./types/primitives";
+import { Connection, Synchronization } from "./types/wasm";
 
 // Spectoda.js -> SpectodaRuntime.js -> | SpectodaXXXConnector.js ->
 
@@ -502,17 +500,17 @@ export class SpectodaRuntime {
    * @returns {Function} unbind function
    */
 
-  addEventListener<K extends keyof SpectodaJsEventMap>(event: K, callback: (props: SpectodaJsEventMap[K]) => void) {
+  addEventListener<K extends keyof SpectodaAppEventMap>(event: K, callback: (props: SpectodaAppEventMap[K]) => void) {
     return this.on(event, callback);
   }
   /**
    * @alias this.addEventListener
    */
-  on<K extends keyof SpectodaJsEventMap>(event: K, callback: (props: SpectodaJsEventMap[K]) => void) {
+  on<K extends keyof SpectodaAppEventMap>(event: K, callback: (props: SpectodaAppEventMap[K]) => void) {
     return this.#eventEmitter.on(event, callback);
   }
 
-  emit<K extends keyof SpectodaJsEventMap>(event: K, ...args: SpectodaJsEventMap[K] extends any[] ? SpectodaJsEventMap[K] : [SpectodaJsEventMap[K]] | []) {
+  emit<K extends keyof SpectodaAppEventMap>(event: K, ...args: SpectodaAppEventMap[K] extends any[] ? SpectodaAppEventMap[K] : [SpectodaAppEventMap[K]] | []) {
     this.#eventEmitter.emit(event, ...args);
   }
 
@@ -1570,7 +1568,7 @@ export class SpectodaRuntime {
     return this.spectoda_js.getClockTimestamp();
   }
 
-  getEventStates(event_state_name: string, event_state_ids: SpectodaTypes.IDs): (EventStateValue | undefined)[] {
+  getEventStates(event_state_name: string, event_state_ids: SpectodaTypes.IDs): (SpectodaEventStateValue | undefined)[] {
     if (Array.isArray(event_state_ids)) {
       return event_state_ids.map(id => this.spectoda_js.getEventState(event_state_name, id));
     } else {
@@ -1578,7 +1576,7 @@ export class SpectodaRuntime {
     }
   }
 
-  getEventState(event_state_name: string, event_state_id: SpectodaTypes.ID): EventStateValue | undefined {
+  getEventState(event_state_name: string, event_state_id: SpectodaTypes.ID): SpectodaEventStateValue | undefined {
     return this.spectoda_js.getEventState(event_state_name, event_state_id);
   }
 

--- a/src/Spectoda_JS.ts
+++ b/src/Spectoda_JS.ts
@@ -4,7 +4,7 @@ import { sleep } from "../functions";
 import { logging } from "../logging";
 import { SpectodaRuntime } from "./SpectodaRuntime";
 import { SpectodaWasm } from "./SpectodaWasm";
-import { EventStateValue } from "./types/event";
+import { SpectodaEventStateValue } from "./types/event";
 import { Connection, IConnector_WASM, IConnector_WASMImplementation, Spectoda_WASM, Spectoda_WASMImplementation, Synchronization, Uint8Vector, Value, interface_error_t } from "./types/wasm";
 
 // Implements Spectoda_JS in javascript
@@ -615,7 +615,7 @@ export class Spectoda_JS {
     this.#spectoda_wasm.eraseTngl();
   }
 
-  getEventState(event_state_name: string, event_state_id: number): EventStateValue | undefined {
+  getEventState(event_state_name: string, event_state_id: number): SpectodaEventStateValue | undefined {
     logging.verbose(`Spectoda_JS::getEventState(event_state_name=${event_state_name}, event_state_id=${event_state_id})`);
 
     if (!this.#spectoda_wasm) {

--- a/src/types/app-events.ts
+++ b/src/types/app-events.ts
@@ -1,5 +1,5 @@
 import { CONNECTION_STATUS, ConnectionStatus, WEBSOCKET_CONNECTION_STATE, WebsocketConnectionState } from "./connect";
-import { Event } from "./event";
+import { SpectodaEvent } from "./event";
 import { SpectodaTypes } from "./primitives";
 
 type WebsocketConnectionStateProps = {
@@ -37,20 +37,20 @@ type PropsMap = WebsocketConnectionStateProps &
 
     // TODO deprecate @immakermatty
     // TODO for future payload key: `events`
-    emitted_events: Event[];
+    emitted_events: SpectodaEvent[];
 
     // TODO deprecate @immakermatty
     // TODO for future payload key: `events`
-    event_state_updates: Event[];
+    event_state_updates: SpectodaEvent[];
 
     // TODO for future payload key: `events`
-    emittedevents: Event[];
+    emittedevents: SpectodaEvent[];
     // TODO for future payload key: `events`
-    eventstateupdates: Event[];
+    eventstateupdates: SpectodaEvent[];
 
     // TODO deprecate @immakermatty
     // TODO for future payload key: `command`
-    wasm_execute: any ;
+    wasm_execute: any;
 
     // TODO deprecate @immakermatty
     // TODO for future payload key: `clock`
@@ -61,7 +61,7 @@ type PropsMap = WebsocketConnectionStateProps &
     "controller-log": string;
   };
 
-export const SpectodaJsEvents = {
+export const SpectodaAppEvents = {
   ...CONNECTION_STATUS,
 
   "CONNECTING-WEBSOCKETS": WEBSOCKET_CONNECTION_STATE.CONNECTING,
@@ -91,10 +91,10 @@ export const SpectodaJsEvents = {
   "CONTROLLER-LOG": "controller-log",
 } as const;
 
-export type SpectodaJsEventName = (typeof SpectodaJsEvents)[keyof typeof SpectodaJsEvents];
+export type SpectodaAppEventName = (typeof SpectodaAppEvents)[keyof typeof SpectodaAppEvents];
 
-export type SpectodaJsEventMap = {
-  [K in SpectodaJsEventName]: PropsMap[K];
+export type SpectodaAppEventMap = {
+  [K in SpectodaAppEventName]: PropsMap[K];
 };
 
-export const SPECTODA_JS_EVENTS = Object.freeze(SpectodaJsEvents);
+export const SPECTODA_APP_EVENTS = Object.freeze(SpectodaAppEvents);

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -2,7 +2,7 @@ import { SpectodaTypes } from "./primitives";
 
 import { VALUE_TYPE } from "../constants";
 
-type EventBase = {
+type SpectodaEventBase = {
   /** Readonly string with more information about the event value */
   debug: string;
 
@@ -17,56 +17,56 @@ type EventBase = {
   id: SpectodaTypes.ID;
 };
 
-type NumberEvent = EventBase & {
+type SpectodaNumberEvent = SpectodaEventBase & {
   type: typeof VALUE_TYPE.NUMBER;
   value: SpectodaTypes.Number;
 };
 
-type LabelEvent = EventBase & {
+type SpectodaLabelEvent = SpectodaEventBase & {
   type: typeof VALUE_TYPE.LABEL;
   value: SpectodaTypes.Label;
 };
 
-type PercentageEvent = EventBase & {
+type SpectodaPercentageEvent = SpectodaEventBase & {
   type: typeof VALUE_TYPE.PERCENTAGE;
   value: SpectodaTypes.Percentage;
 };
 
-type TimestampEvent = EventBase & {
+type SpectodaTimestampEvent = SpectodaEventBase & {
   type: typeof VALUE_TYPE.TIME;
   value: SpectodaTypes.Timestamp;
 };
 
-type ColorEvent = EventBase & {
+type SpectodaColorEvent = SpectodaEventBase & {
   type: typeof VALUE_TYPE.COLOR;
   value: SpectodaTypes.Color;
 };
 
-type PixelsEvent = EventBase & {
+type SpectodaPixelsEvent = SpectodaEventBase & {
   type: typeof VALUE_TYPE.PIXELS;
   value: SpectodaTypes.Pixels;
 };
 
-type BooleanEvent = EventBase & {
+type SpectodaBooleanEvent = SpectodaEventBase & {
   type: typeof VALUE_TYPE.BOOLEAN;
   value: SpectodaTypes.Boolean;
 };
 
-type NullEvent = EventBase & {
+type SpectodaNullEvent = SpectodaEventBase & {
   type: typeof VALUE_TYPE.NULL;
   value: SpectodaTypes.Null;
 };
 
-type UndefinedEvent = EventBase & {
+type SpectodaUndefinedEvent = SpectodaEventBase & {
   type: typeof VALUE_TYPE.UNDEFINED;
   value: SpectodaTypes.Undefined;
 };
 
-export type Event = NumberEvent | LabelEvent | PercentageEvent | TimestampEvent | ColorEvent | PixelsEvent | BooleanEvent | NullEvent | UndefinedEvent;
+export type SpectodaEvent = SpectodaNumberEvent | SpectodaLabelEvent | SpectodaPercentageEvent | SpectodaTimestampEvent | SpectodaColorEvent | SpectodaPixelsEvent | SpectodaBooleanEvent | SpectodaNullEvent | SpectodaUndefinedEvent;
 
 /**
- * EventStateValue type is equivalent to Event
+ * SpectodaEventStateValue type is equivalent to SpectodaEvent
  *
- * @alias Event
+ * @alias SpectodaEvent
  */
-export type EventStateValue = Event;
+export type SpectodaEventStateValue = SpectodaEvent;

--- a/src/types/spectodaClass.ts
+++ b/src/types/spectodaClass.ts
@@ -1,7 +1,7 @@
 import { TimeTrack } from "../../TimeTrack";
 import { SpectodaRuntime } from "../SpectodaRuntime";
+import { SpectodaAppEventMap } from "./app-events";
 import { ConnectorType } from "./connect";
-import { SpectodaJsEventMap } from "./spectoda-js-events";
 import { SpectodaTypes } from "./primitives";
 
 export interface SpectodaClass {
@@ -32,8 +32,8 @@ export interface SpectodaClass {
   getOwnerKey(): SpectodaTypes.NetworkKey;
 
   // Event handling
-  addEventListener<K extends keyof SpectodaJsEventMap>(event: K, callback: (props: SpectodaJsEventMap[K]) => void): () => void;
-  on<K extends keyof SpectodaJsEventMap>(event: K, callback: (props: SpectodaJsEventMap[K]) => void): () => void;
+  addEventListener<K extends keyof SpectodaAppEventMap>(event: K, callback: (props: SpectodaAppEventMap[K]) => void): () => void;
+  on<K extends keyof SpectodaAppEventMap>(event: K, callback: (props: SpectodaAppEventMap[K]) => void): () => void;
 
   // TNGL methods
   preprocessTngl(tngl_code: string): Promise<string>;

--- a/src/types/wasm.ts
+++ b/src/types/wasm.ts
@@ -1,4 +1,4 @@
-import { Event } from "./event";
+import { SpectodaEvent } from "./event";
 
 /// === auto-generated from Emscripten build process === ///
 /// ========== DEBUG_DEV_0.12.3_20241218.d.ts ========== ///
@@ -288,8 +288,8 @@ export interface Spectoda_WASMImplementation {
   // // __construct: function () {}
   // // __destruct: function () {}
   _onTnglUpdate(tngl_bytes: Uint8Vector, used_ids: Uint8Vector): boolean;
-  _onEvents(event_array: Event[]): boolean;
-  _onEventStateUpdates(event_array: Event[]): boolean;
+  _onEvents(event_array: SpectodaEvent[]): boolean;
+  _onEventStateUpdates(event_array: SpectodaEvent[]): boolean;
   _onExecute(execute_bytecode: Uint8Vector): boolean;
   _onRequest(request_ticket_number: number, request_bytecode_vector: Uint8Vector, destination_connection: Connection): boolean;
   _onSynchronize(synchronization: Synchronization): boolean;


### PR DESCRIPTION
- jsEvent -> spectodaAppEvent
- event -> spectdaEvent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Refactor**
	- Renamed event-related types and constants to improve clarity and consistency
	- Updated event handling mechanisms across multiple files
	- Replaced generic `Event` types with more specific `SpectodaEvent` types

- **Type Changes**
	- Introduced new event mapping structure
	- Updated method signatures to use new event type definitions
	- Standardized event-related type names with `Spectoda` prefix

These changes enhance the type safety and readability of the event handling system without altering core functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->