### PR TITLE
refactor: convert hardcoded string keys to SpectodaAppEvents

### DIFF
--- a/Spectoda.ts
+++ b/Spectoda.ts
@@ -3394,7 +3394,8 @@ export class Spectoda implements SpectodaClass {
   }
 
   /**
-   * Emits JS events from SpectodaAppEvents
+   * Emits SpectodaAppEvents
+   * TODO: should be private and renamed to `emitAppEvent` as SpectodaCore should not be able to emit AppEvents on Spectoda object
    */
   emit(event: SpectodaAppEventName, value: any) {
     this.runtime.emit(event, value)

--- a/SpectodaDummyConnector.js
+++ b/SpectodaDummyConnector.js
@@ -4,6 +4,7 @@ import { TimeTrack } from './TimeTrack.js';
 import { COMMAND_FLAGS } from './src/constants';
 import { TnglReader } from './TnglReader';
 import { TnglWriter } from './TnglWriter';
+import { SpectodaAppEvents } from './src/types/app-events';
 
 /////////////////////////////////////////////////////////////////////////////////////
 
@@ -138,7 +139,7 @@ export class SpectodaDummyConnector {
         return;
       }
       this.#connected = true;
-      this.#interfaceReference.emit('#connected');
+      this.#interfaceReference.emit(SpectodaAppEvents.PRIVATE_CONNECTED);
       resolve({ connector: this.type });
 
       /**  
@@ -159,7 +160,7 @@ export class SpectodaDummyConnector {
       if (this.#connected) {
         await sleep(100); // disconnecting logic
         this.#connected = false;
-        this.#interfaceReference.emit('#disconnected');
+        this.#interfaceReference.emit(SpectodaAppEvents.PRIVATE_DISCONNECTED);
       }
       resolve(); // always resolves even if there are internal errors
     });
@@ -339,29 +340,29 @@ export class SpectodaDummyConnector {
         reject('DeviceDisconnected');
         return;
       }
-      this.#interfaceReference.emit('ota_status', 'begin');
+      this.#interfaceReference.emit(SpectodaAppEvents.OTA_STATUS, 'begin');
       await sleep(10000); // preparing FW logic.
       if (this.#fail(0.1)) {
-        this.#interfaceReference.emit('ota_status', 'fail');
+        this.#interfaceReference.emit(SpectodaAppEvents.OTA_STATUS, 'fail');
         reject('UpdateFailed');
         return;
       }
       for (let i = 1; i <= 100; i++) {
-        this.#interfaceReference.emit('ota_progress', i);
+        this.#interfaceReference.emit(SpectodaAppEvents.OTA_PROGRESS, i);
         await sleep(25); // writing FW logic.
         if (this.#fail(0.01)) {
-          this.#interfaceReference.emit('ota_status', 'fail');
+          this.#interfaceReference.emit(SpectodaAppEvents.OTA_STATUS, 'fail');
           reject('UpdateFailed');
           return;
         }
       }
       await sleep(1000); // finishing FW logic.
       if (this.#fail(0.1)) {
-        this.#interfaceReference.emit('ota_status', 'fail');
+        this.#interfaceReference.emit(SpectodaAppEvents.OTA_STATUS, 'fail');
         reject('UpdateFailed');
         return;
       }
-      this.#interfaceReference.emit('ota_status', 'success');
+      this.#interfaceReference.emit(SpectodaAppEvents.OTA_STATUS, 'success');
       resolve();
     });
   }

--- a/SpectodaWebSocketsConnector.js
+++ b/SpectodaWebSocketsConnector.js
@@ -4,7 +4,7 @@ import { io } from 'socket.io-client';
 
 import customParser from 'socket.io-msgpack-parser';
 
-import { SpectodaAppEvents } from './types/app-events';
+import { SpectodaAppEvents } from './src/types/app-events';
 
 import { TimeTrack } from './TimeTrack';
 import { createNanoEvents } from './functions';

--- a/src/PreviewController.ts
+++ b/src/PreviewController.ts
@@ -387,6 +387,7 @@ export class PreviewController {
     return this.#ringLogBuffer.getAllLogs();
   }
 
+  // TODO! remove this
   clearLogs() {
     this.#ringLogBuffer.clear();
     this.#eventEmitter.emit('clear_logs');

--- a/src/SpectodaRuntime.ts
+++ b/src/SpectodaRuntime.ts
@@ -405,7 +405,7 @@ export class SpectodaRuntime {
 
     this.previewControllers = {};
 
-    this.#eventEmitter.on(SPECTODA_APP_EVENTS.PRIVATE_WASM_EXECUTE, (command: any) => {
+    this.#eventEmitter.on(SPECTODA_APP_EVENTS.PRIVATE_WASM_EXECUTE, (command: Uint8Array) => {
       for (const previewController of Object.values(this.previewControllers)) {
         try {
           previewController.execute(command, SpectodaWasm.Connection.make('11:11:11:11:11:11', SpectodaWasm.connector_type_t.CONNECTOR_UNDEFINED, SpectodaWasm.connection_rssi_t.RSSI_MAX));
@@ -1212,7 +1212,7 @@ export class SpectodaRuntime {
                   const send_execute_query: SendExecuteQuery = item.a;
 
                   try {
-                    this.emit(SpectodaAppEvents.PRIVATE_WASM_EXECUTE, [...send_execute_query.command_bytes]);
+                    this.emit(SpectodaAppEvents.PRIVATE_WASM_EXECUTE, send_execute_query.command_bytes);
 
                     await this.connector
                       .sendExecute(send_execute_query.command_bytes, send_execute_query.source_connection)

--- a/src/connector/SpectodaNodeSerialConnector.ts
+++ b/src/connector/SpectodaNodeSerialConnector.ts
@@ -29,6 +29,7 @@ import { Connection, Synchronization } from '../types/wasm';
 
 // import { SerialPort as NodeSerialPort, ReadlineParser as NodeReadlineParser } from "serialport";
 import type { SerialPort as NodeSerialPortType, ReadlineParser as NodeReadlineParserType } from '../../../../node_modules/serialport/dist/index';
+import { SpectodaAppEvents } from '../types/app-events';
 
 let { NodeSerialPort, NodeReadlineParser }: { NodeSerialPort: NodeSerialPortType | undefined; NodeReadlineParser: NodeReadlineParserType | undefined } = { NodeSerialPort: undefined, NodeReadlineParser: undefined };
 
@@ -392,7 +393,7 @@ export class SpectodaNodeSerialConnector {
 
           if (this.#interfaceConnected) {
             this.#interfaceConnected = false;
-            this.#runtimeReference.emit('#disconnected');
+            this.#runtimeReference.emit(SpectodaAppEvents.PRIVATE_DISCONNECTED);
           }
         });
 
@@ -502,7 +503,6 @@ export class SpectodaNodeSerialConnector {
 
                     // TODO! process line
                     logging.info(line);
-                    this.#runtimeReference.emit('controller-log', line);
                     line_bytes.length = 0;
                   } /* if(character !== NEWLINE_ASCII_CODE) */ else {
                     line_bytes.push(character);
@@ -560,7 +560,7 @@ export class SpectodaNodeSerialConnector {
               setTimeout(() => {
                 if (!this.#interfaceConnected) {
                   this.#interfaceConnected = true;
-                  this.#runtimeReference.emit('#connected');
+                  this.#runtimeReference.emit(SpectodaAppEvents.PRIVATE_CONNECTED);
                 }
                 resolve({ connector: this.type });
               }, 100);
@@ -633,7 +633,7 @@ export class SpectodaNodeSerialConnector {
         }
         if (this.#interfaceConnected) {
           this.#interfaceConnected = false;
-          this.#runtimeReference.emit('#disconnected');
+          this.#runtimeReference.emit(SpectodaAppEvents.PRIVATE_DISCONNECTED);
         }
       });
     }
@@ -996,7 +996,7 @@ export class SpectodaNodeSerialConnector {
       const start_timestamp = Date.now();
 
       try {
-        this.#runtimeReference.emit('ota_status', 'begin');
+        this.#runtimeReference.emit(SpectodaAppEvents.OTA_STATUS, 'begin');
 
         {
           //===========// RESET //===========//
@@ -1038,7 +1038,7 @@ export class SpectodaNodeSerialConnector {
 
             logging.info(percentage + '%');
 
-            this.#runtimeReference.emit('ota_progress', percentage);
+            this.#runtimeReference.emit(SpectodaAppEvents.OTA_PROGRESS, percentage);
 
             index_from += chunk_size;
             index_to = index_from + chunk_size;
@@ -1064,11 +1064,11 @@ export class SpectodaNodeSerialConnector {
 
         await this.#write(CHANNEL_DEVICE, bytes, 10000);
 
-        this.#runtimeReference.emit('ota_status', 'success');
+        this.#runtimeReference.emit(SpectodaAppEvents.OTA_STATUS, 'success');
         resolve(null);
       } catch (e) {
         logging.error('Error during OTA:', e);
-        this.#runtimeReference.emit('ota_status', 'fail');
+        this.#runtimeReference.emit(SpectodaAppEvents.OTA_STATUS, 'fail');
         reject('UpdateFailed');
       }
     }).finally(() => {

--- a/src/connector/SpectodaSimulatedConnector.ts
+++ b/src/connector/SpectodaSimulatedConnector.ts
@@ -11,6 +11,7 @@ import { SpectodaTypes } from '../types/primitives';
 import { Connection, Synchronization, Uint8Vector } from '../types/wasm';
 
 import { IConnector_JS } from './IConnector_JS';
+import { SpectodaAppEvents } from '../types/app-events';
 
 export const SIMULATED_MAC_ADDRESS = '00:00:23:34:45:56';
 
@@ -373,7 +374,7 @@ export class SpectodaSimulatedConnector {
       await sleep(Math.random() * 1000); // connecting logic process delay
 
       this.#connected = true;
-      this.#runtimeReference.emit('#connected');
+      this.#runtimeReference.emit(SpectodaAppEvents.PRIVATE_CONNECTED);
       resolve({ connector: this.type });
     });
   }
@@ -387,7 +388,7 @@ export class SpectodaSimulatedConnector {
         await sleep(100); // disconnecting logic process delay
 
         this.#connected = false;
-        this.#runtimeReference.emit('#disconnected');
+        this.#runtimeReference.emit(SpectodaAppEvents.PRIVATE_DISCONNECTED);
       }
       resolve(null); // always resolves even if there are internal errors
     });
@@ -540,17 +541,17 @@ export class SpectodaSimulatedConnector {
         reject('DeviceDisconnected');
         return;
       }
-      this.#runtimeReference.emit('ota_status', 'begin');
+      this.#runtimeReference.emit(SpectodaAppEvents.OTA_STATUS, 'begin');
       await sleep(4000); // preparing FW logic.
 
       for (let i = 1; i <= 100; i++) {
-        this.#runtimeReference.emit('ota_progress', i);
+        this.#runtimeReference.emit(SpectodaAppEvents.OTA_PROGRESS, i);
         await sleep(25); // writing FW logic.
       }
 
       await sleep(1000); // finishing FW logic.
 
-      this.#runtimeReference.emit('ota_status', 'success');
+      this.#runtimeReference.emit(SpectodaAppEvents.OTA_STATUS, 'success');
       resolve(null);
     });
   }

--- a/src/connector/SpectodaWebSerialConnector.ts
+++ b/src/connector/SpectodaWebSerialConnector.ts
@@ -14,6 +14,7 @@ import { SpectodaRuntime } from '../SpectodaRuntime';
 import { SpectodaWasm } from '../SpectodaWasm';
 import { SpectodaTypes } from '../types/primitives';
 import { Connection, Synchronization } from '../types/wasm';
+import { SpectodaAppEvents } from '../types/app-events';
 
 // ! ======= from "@types/w3c-web-serial" =======
 
@@ -601,7 +602,6 @@ export class SpectodaWebSerialConnector {
                           const line = decoder.decode(new Uint8Array(line_bytes));
 
                           logging.info(line);
-                          this.#runtimeReference.emit('controller-log', line);
                           line_bytes.length = 0;
                         } else {
                           line_bytes.push(character);
@@ -668,7 +668,7 @@ export class SpectodaWebSerialConnector {
             
             // Set connected state and resolve
             this.#interfaceConnected = true;
-            this.#runtimeReference.emit('#connected');
+            this.#runtimeReference.emit(SpectodaAppEvents.PRIVATE_CONNECTED);
             resolveOnce({ connector: this.type });
           } else {
             logging.warn('Serial connection failed');
@@ -751,7 +751,7 @@ export class SpectodaWebSerialConnector {
         this.#disconnecting = false;
         if (this.#interfaceConnected) {
           this.#interfaceConnected = false;
-          this.#runtimeReference.emit('#disconnected');
+          this.#runtimeReference.emit(SpectodaAppEvents.PRIVATE_DISCONNECTED);
         }
       }
     });
@@ -812,7 +812,7 @@ export class SpectodaWebSerialConnector {
       this.#disconnecting = false;
       if (this.#interfaceConnected) {
         this.#interfaceConnected = false;
-        this.#runtimeReference.emit('#disconnected');
+        this.#runtimeReference.emit(SpectodaAppEvents.PRIVATE_DISCONNECTED);
       }
     }
   }
@@ -1111,7 +1111,7 @@ export class SpectodaWebSerialConnector {
       const start_timestamp = Date.now();
 
       try {
-        this.#runtimeReference.emit('ota_status', 'begin');
+        this.#runtimeReference.emit(SpectodaAppEvents.OTA_STATUS, 'begin');
 
         {
           logging.info('OTA RESET');
@@ -1150,7 +1150,7 @@ export class SpectodaWebSerialConnector {
 
             logging.info(percentage + '%');
 
-            this.#runtimeReference.emit('ota_progress', percentage);
+            this.#runtimeReference.emit(SpectodaAppEvents.OTA_PROGRESS, percentage);
 
             index_from += chunk_size;
             index_to = index_from + chunk_size;
@@ -1175,11 +1175,11 @@ export class SpectodaWebSerialConnector {
 
         await this.#write(CHANNEL_DEVICE, bytes, 10000);
 
-        this.#runtimeReference.emit('ota_status', 'success');
+        this.#runtimeReference.emit(SpectodaAppEvents.OTA_STATUS, 'success');
         resolve(null);
       } catch (e) {
         logging.error('Error during OTA:', e);
-        this.#runtimeReference.emit('ota_status', 'fail');
+        this.#runtimeReference.emit(SpectodaAppEvents.OTA_STATUS, 'fail');
         reject('UpdateFailed');
       }
     }).finally(() => {

--- a/src/types/app-events.ts
+++ b/src/types/app-events.ts
@@ -1,15 +1,15 @@
 import {
   CONNECTION_STATUS,
   ConnectionStatus,
-  WEBSOCKET_CONNECTION_STATE,
-  WebsocketConnectionState,
+  REMOTECONTROL_STATUS,
+  RemoteControlConnectionStatus,
 } from './connect'
 import { ControllerError, ControllerWarning } from './messages'
 import { SpectodaEvent } from './event'
 import { SpectodaTypes } from './primitives'
 
-type WebsocketConnectionStateProps = {
-  [K in WebsocketConnectionState]: undefined
+type RemoteControlConnectionStatusProps = {
+  [K in RemoteControlConnectionStatus]: undefined
 }
 
 type ConnectionStatusProps = {
@@ -22,13 +22,9 @@ type SpectodaAppEventType<T extends string = string> = {
 
 export const SpectodaAppEvents = {
   ...CONNECTION_STATUS,
+  ...REMOTECONTROL_STATUS,
 
   SCAN_RESULTS: 'scan_results',
-
-  REMOTE_CONTROL_CONNECTING: WEBSOCKET_CONNECTION_STATE.CONNECTING,
-  REMOTE_CONTROL_CONNECTED: WEBSOCKET_CONNECTION_STATE.CONNECTED,
-  REMOTE_CONTROL_DISCONNECTING: WEBSOCKET_CONNECTION_STATE.DISCONNECTING,
-  REMOTE_CONTROL_DISCONNECTED: WEBSOCKET_CONNECTION_STATE.DISCONNECTED,
 
   PEER_CONNECTED: 'peer_connected',
   PEER_DISCONNECTED: 'peer_disconnected',
@@ -58,7 +54,7 @@ export const SpectodaAppEvents = {
   
 } as const satisfies SpectodaAppEventType
 
-type PropsMap = WebsocketConnectionStateProps &
+type PropsMap = RemoteControlConnectionStatusProps &
   ConnectionStatusProps & {
 
     // TODO for future payload key: `json`
@@ -84,12 +80,6 @@ type PropsMap = WebsocketConnectionStateProps &
       used_ids: SpectodaTypes.UsedIds
     }
 
-    /** @private event */
-    '#connected': undefined
-
-    /** @private event */
-    '#disconnected': undefined
-
     // TODO for future payload key: `events`
     [SpectodaAppEvents.EVENT_STATE_UPDATES]: SpectodaEvent[]
 
@@ -98,6 +88,21 @@ type PropsMap = WebsocketConnectionStateProps &
 
     [SpectodaAppEvents.NETWORK_ERROR]: ControllerError
     [SpectodaAppEvents.NETWORK_WARNING]: ControllerWarning
+
+    /** @private event */
+    [SpectodaAppEvents.PRIVATE_CONNECTED]: undefined
+
+    /** @private event */
+    [SpectodaAppEvents.PRIVATE_DISCONNECTED]: undefined
+
+    /** @private event */
+    [SpectodaAppEvents.PRIVATE_WASM_CLOCK]: number
+
+    /** @private event */
+    [SpectodaAppEvents.PRIVATE_WASM_REQUEST]: Uint8Array
+
+    /** @private event */
+    [SpectodaAppEvents.PRIVATE_WASM_EXECUTE]: Uint8Array
   }
 
 export type SpectodaAppEventName =

--- a/src/types/app-events.ts
+++ b/src/types/app-events.ts
@@ -23,10 +23,12 @@ type SpectodaAppEventType<T extends string = string> = {
 export const SpectodaAppEvents = {
   ...CONNECTION_STATUS,
 
-  'CONNECTING-WEBSOCKETS': WEBSOCKET_CONNECTION_STATE.CONNECTING,
-  'CONNECTED-WEBSOCKETS': WEBSOCKET_CONNECTION_STATE.CONNECTED,
-  'DISCONNECTING-WEBSOCKETS': WEBSOCKET_CONNECTION_STATE.DISCONNECTING,
-  'DISCONNECTED-WEBSOCKETS': WEBSOCKET_CONNECTION_STATE.DISCONNECTED,
+  SCAN_RESULTS: 'scan_results',
+
+  REMOTE_CONTROL_CONNECTING: WEBSOCKET_CONNECTION_STATE.CONNECTING,
+  REMOTE_CONTROL_CONNECTED: WEBSOCKET_CONNECTION_STATE.CONNECTED,
+  REMOTE_CONTROL_DISCONNECTING: WEBSOCKET_CONNECTION_STATE.DISCONNECTING,
+  REMOTE_CONTROL_DISCONNECTED: WEBSOCKET_CONNECTION_STATE.DISCONNECTED,
 
   PEER_CONNECTED: 'peer_connected',
   PEER_DISCONNECTED: 'peer_disconnected',
@@ -37,24 +39,31 @@ export const SpectodaAppEvents = {
 
   TNGL_UPDATE: 'tngl_update',
 
-  
   EMITTED_EVENTS: 'emittedevents',
-  
   EVENT_STATE_UPDATES: 'eventstateupdates',
-
-  WASM_EXECUTE: 'wasm_execute',
-  WASM_CLOCK: 'wasm_clock',
-
-  '#CONNECTED': '#connected',
-  '#DISCONNECTED': '#disconnected',
-  'CONTROLLER-LOG': 'controller-log',
 
   NETWORK_ERROR: 'networkerror',
   NETWORK_WARNING: 'networkwarning',
+
+  /** @private for spectoda-js internal use only */
+  PRIVATE_CONNECTED: '#connected',
+  /** @private for spectoda-js internal use only */
+  PRIVATE_DISCONNECTED: '#disconnected',
+  /** @private for spectoda-js internal use only */
+  PRIVATE_WASM_CLOCK: '#wasm_clock',
+  /** @private for spectoda-js internal use only */
+  PRIVATE_WASM_REQUEST: '#wasm_request',
+  /** @private for spectoda-js internal use only */
+  PRIVATE_WASM_EXECUTE: '#wasm_execute',
+  
 } as const satisfies SpectodaAppEventType
 
 type PropsMap = WebsocketConnectionStateProps &
   ConnectionStatusProps & {
+
+    // TODO for future payload key: `json`
+    [SpectodaAppEvents.SCAN_RESULTS]: string
+
     // TODO for future payload key: `mac`
     [SpectodaAppEvents.PEER_CONNECTED]: string
 
@@ -86,18 +95,6 @@ type PropsMap = WebsocketConnectionStateProps &
 
     // TODO for future payload key: `events`
     [SpectodaAppEvents.EMITTED_EVENTS]: SpectodaEvent[]
-
-    // TODO deprecate @immakermatty
-    // TODO for future payload key: `command`
-    [SpectodaAppEvents.WASM_EXECUTE]: any
-
-    // TODO deprecate @immakermatty
-    // TODO for future payload key: `clock`
-    [SpectodaAppEvents.WASM_CLOCK]: number
-
-    // TODO deprecate @immakermatty
-    // TODO for future payload key: `log`
-    'controller-log': string
 
     [SpectodaAppEvents.NETWORK_ERROR]: ControllerError
     [SpectodaAppEvents.NETWORK_WARNING]: ControllerWarning

--- a/src/types/connect.ts
+++ b/src/types/connect.ts
@@ -16,6 +16,7 @@ export const CONNECTION_STATUS = Object.freeze({
 export type ConnectionStatus =
   (typeof CONNECTION_STATUS)[keyof typeof CONNECTION_STATUS]
 
+// TODO! rename to REMOTE_CONTROL_CONNECTION_STATUS
 export const WEBSOCKET_CONNECTION_STATE = Object.freeze({
   CONNECTING: 'connecting-websockets',
   CONNECTED: 'connected-websockets',

--- a/src/types/connect.ts
+++ b/src/types/connect.ts
@@ -16,13 +16,18 @@ export const CONNECTION_STATUS = Object.freeze({
 export type ConnectionStatus =
   (typeof CONNECTION_STATUS)[keyof typeof CONNECTION_STATUS]
 
-// TODO! rename to REMOTE_CONTROL_CONNECTION_STATUS
-export const WEBSOCKET_CONNECTION_STATE = Object.freeze({
-  CONNECTING: 'connecting-websockets',
-  CONNECTED: 'connected-websockets',
-  DISCONNECTING: 'disconnecting-websockets',
-  DISCONNECTED: 'disconnected-websockets',
+export const REMOTECONTROL_STATUS = Object.freeze({
+  REMOTECONTROL_CONNECTED: 'connected-websockets',
+  REMOTECONTROL_CONNECTING: 'connecting-websockets',
+  REMOTECONTROL_DISCONNECTED: 'disconnected-websockets',
+  REMOTECONTROL_DISCONNECTING: 'disconnecting-websockets',
 })
 
-export type WebsocketConnectionState =
-  (typeof WEBSOCKET_CONNECTION_STATE)[keyof typeof WEBSOCKET_CONNECTION_STATE]
+export type RemoteControlConnectionStatus =
+  (typeof REMOTECONTROL_STATUS)[keyof typeof REMOTECONTROL_STATUS]
+
+/** @deprecated Use REMOTECONTROL_STATUS instead */
+export const WEBSOCKET_CONNECTION_STATE = REMOTECONTROL_STATUS;
+
+/** @deprecated Use RemoteControlConnectionStatus instead */
+export type WebsocketConnectionState = RemoteControlConnectionStatus;


### PR DESCRIPTION
also removing depretaced JS events with no use for SpectodaCore in the process. Like wasm_clock, wasm_request and wasm_execute