### PR TITLE
refactor: time to timestamp

### DIFF
--- a/Spectoda.ts
+++ b/Spectoda.ts
@@ -3700,7 +3700,7 @@ export class Spectoda implements SpectodaClass {
         }
         case 'timestamp':
         case 'time':
-        case VALUE_TYPE.TIME: {
+        case VALUE_TYPE.TIMESTAMP: {
           this.emitTimestamp(event.label, event.value as number, event.id)
           break
         }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,7 +4,7 @@ import { SpectodaTypes } from '../types/primitives'
 export const VALUE_TYPE = Object.freeze({
   NUMBER: 29,
   LABEL: 31,
-  TIME: 32,
+  TIMESTAMP: 32,
   PERCENTAGE: 30,
   DATE: 28,
   COLOR: 26,
@@ -43,10 +43,12 @@ export const CONNECTORS = Object.freeze({
 export const DEFAULT_CONNECTOR = CONNECTORS.DEFAULT
 
 /** No Network Signature */
-export const NO_NETWORK_SIGNATURE: SpectodaTypes.NetworkSignature = '00000000000000000000000000000000'
+export const NO_NETWORK_SIGNATURE: SpectodaTypes.NetworkSignature =
+  '00000000000000000000000000000000'
 
 /** No Network Key */
-export const NO_NETWORK_KEY: SpectodaTypes.NetworkKey = '00000000000000000000000000000000'
+export const NO_NETWORK_KEY: SpectodaTypes.NetworkKey =
+  '00000000000000000000000000000000'
 
 /** Default MAC address for the app */
 export const APP_MAC_ADDRESS = '00:00:12:34:56:78'

--- a/src/constants/values.ts
+++ b/src/constants/values.ts
@@ -37,7 +37,7 @@ export const JS_EVENT_VALUE_LIMITS = Object.freeze({
 export const VALUE_TYPES = Object.freeze({
   NUMBER: 29,
   LABEL: 31,
-  TIME: 32,
+  TIMESTAMP: 32,
   PERCENTAGE: 30,
   DATE: 28,
   COLOR: 26,

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -36,7 +36,7 @@ export type SpectodaPercentageEvent = SpectodaEventBase & {
 }
 
 export type SpectodaTimestampEvent = SpectodaEventBase & {
-  type: typeof VALUE_TYPE.TIME
+  type: typeof VALUE_TYPE.TIMESTAMP
   value: SpectodaTypes.Timestamp
 }
 


### PR DESCRIPTION
The language was incoherent. We were always calling the timestamp value "timestamps", and in spectoda-js constants it was called time. Not anymore