### PR TITLE
chore: update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+todoctor


### PR DESCRIPTION
added todoctor to spectoda-js in order to ignore the files generated by todoctor - package for analysing number of todos in a repository