### PR TITLE
ID EventState Rules for TNGL - ID Group, ID EventState Interface, ID Scoping 

### DIFF
--- a/Spectoda.ts
+++ b/Spectoda.ts
@@ -1778,28 +1778,23 @@ export class Spectoda implements SpectodaClass {
       
       // Reassemble the code
       tngl_code = resultLines.join('\n');
-      
-      // We need a special handling for BERRY code where symbols might appear
-      // Extract BERRY code segments and apply replacements
+    }
+
+    // Process BERRY code blocks after handling preprocessor directives
+    {
+      // Extract and process BERRY code segments
       const berryRegex = /BERRY\(`([\S\s]*?)`\)/g;
       let berryMatch;
       
       while ((berryMatch = berryRegex.exec(tngl_code)) !== null) {
         const fullMatch = berryMatch[0];
-        let berryCode = berryMatch[1];
+        const berryCode = berryMatch[1];
         
-        // Apply symbol replacements within BERRY code
-        for (const [name, value] of defines.entries()) {
-          if (value === null || value === undefined) {
-            continue;
-          }
-          
-          const defineRegex = new RegExp(`\\b${name}\\b`, 'g');
-          berryCode = berryCode.replace(defineRegex, value);
-        }
+        // Process the BERRY code using the preprocessBerry function
+        const processedBerryCode = preprocessBerry(berryCode);
         
         // Replace the original BERRY segment with the processed one
-        const newBerrySegment = `BERRY(\`${berryCode}\`)`;
+        const newBerrySegment = `BERRY(\`${processedBerryCode}\`)`;
         tngl_code = tngl_code.substring(0, berryMatch.index) + 
                     newBerrySegment + 
                     tngl_code.substring(berryMatch.index + fullMatch.length);

--- a/Spectoda.ts
+++ b/Spectoda.ts
@@ -940,17 +940,18 @@ export class Spectoda implements SpectodaClass {
    * Preprocesses TNGL code by handling API injections, removing comments, minifying BERRY code, replacing specific patterns within BERRY code, and handling #define statements.
    * Happens
    *
-   * @param {string} tngl_code - The TNGL code as a string.
-   * @returns {string} - The preprocessed TNGL code.
+   * @param tngl_code The TNGL code as a string.
+   * @returns The preprocessed TNGL code.
    */
   async preprocessTngl(tngl_code: string) {
     logging.verbose(`preprocessTngl(tngl_code=${tngl_code})`)
 
     /**
      * Helper function to parse timestamp strings and convert them to total milliseconds/tics.
+     * TODO move this function to some kind of utils?
      *
-     * @param {string} value - The timestamp string (e.g., "1.2d+9h2m7.2s-123t").
-     * @returns {number} - The total time in milliseconds/tics.
+     * @param value The timestamp string (e.g., "1.2d+9h2m7.2s-123t").
+     * @returns The total time in milliseconds/tics.
      */
     function computeTimestamp(value: string): number {
       if (!value) {
@@ -1009,9 +1010,10 @@ export class Spectoda implements SpectodaClass {
 
     /**
      * Helper function to minify BERRY code by removing # comments, specific patterns, and unnecessary whitespace.
+     * TODO move this function to some kind of utils?
      *
-     * @param {string} berryCode - The BERRY code to minify.
-     * @returns {string} - The minified BERRY code.
+     * @param berryCode The BERRY code to minify.
+     * @returns The minified BERRY code.
      */
     function preprocessBerry(berryCode: string): string {
       let minified = berryCode
@@ -1382,9 +1384,10 @@ export class Spectoda implements SpectodaClass {
     /**
      * Helper function to remove single-line (// ...) and multi-line () comments
      * from non-BERRY code segments.
+     * TODO move this function to some kind of utils?
      *
-     * @param {string} code - The code segment to clean.
-     * @returns {string} - The code without // and  comments.
+     * @param code The code segment to clean.
+     * @returns The code without // and  comments.
      */
     function removeNonBerryComments(code: string): string {
       const commentRegex = /\/\/.*|\/\*[\S\s]*?\*\//g

--- a/Spectoda.ts
+++ b/Spectoda.ts
@@ -1219,12 +1219,11 @@ export class Spectoda implements SpectodaClass {
       // // })
 
       // Pattern B: Timestamps - /([+-]?(\d+\.\d+|\d+|\.\d+))(d|h|m(?!s)|s|ms|t)\b/gi
-      const timestampRegex = /([+-]?(\d+\.\d+|\d+|\.\d+))(d|h|m(?!s)|s|ms|t)\b/gi
+      const timestampRegex = /([+-]?(?:\d+\.\d+|\d+|\.\d+))(d|h|m(?!s)|s|ms|t)\b/gi
 
       minified = minified.replace(timestampRegex, (match) => {
-        const miliseconds = computeTimestamp(match)
-
-        return `Value.Timestamp(${miliseconds})`
+        const milliseconds = computeTimestamp(match)
+        return `Value.Timestamp(${milliseconds})`
       })
 
       // // // Pattern C: Labels - /\$[\w]+/

--- a/SpectodaParser.js
+++ b/SpectodaParser.js
@@ -1143,10 +1143,10 @@ export class TnglCompiler {
       return;
     }
     const code = berryMatch[1];
-    logging.info('Berry script:', code);
+    logging.debug('matched script:', code);
 
     const bytes = new TextEncoder().encode(code);
-    logging.info('Berry script bytes:', bytes);
+    logging.verbose('matched script bytes:', bytes);
 
     this.#tnglWriter.writeFlag(TNGL_FLAGS.BERRY_SCRIPT)
     this.#tnglWriter.writeUint16(bytes.length)

--- a/SpectodaParser.js
+++ b/SpectodaParser.js
@@ -36,8 +36,8 @@ const TNGL_FLAGS = Object.freeze({
   /* frame */
   SCOPE: 11,
 
-  /* clip */
-  CLIP: 12,
+  /* interface implementation */
+  SCOPE_ID: 12,
 
   /* sifters */
   SIFTER_CONTROLLER: 13,
@@ -47,20 +47,20 @@ const TNGL_FLAGS = Object.freeze({
   /* event handlers */
   INTERACTIVE: 16,
   EVENT_CATCHER: 17,
-
+  
   /* definitions scoped */
   DECLARE_VARIABLE: 18,
-
+  
   /* event state */
   EVENTSTATE_OVERLOAD: 19,
-
+  
   // ======================
 
   /* definitions global */
   DEFINE_CONTROLLER: 24,
   DEFINE_SEGMENT: 25,
   DEFINE_CANVAS: 26,
-  DEFINE_MARKS: 27,
+  DEFINE_INTERFACE: 27,
   DEFINE_ANIMATION: 28,
 
   // ======================
@@ -120,17 +120,19 @@ const TNGL_FLAGS = Object.freeze({
   OPERATION_MUL: 163,
   OPERATION_DIV: 164,
   OPERATION_MOD: 165,
-  OPERATION_SCALE: 166,
+  OPERATION_SCA: 166,
   OPERATION_MAP: 167,
+  OPERATION_NVL: 168,
 
   /* objects */
   CONTROLLER: 176,
   IO: 177,
   SEGMENT: 178,
   CANVAS: 180,
-  MARKS: 181,
+  EVENTSTATE: 181,
   ID: 182,
   OBJECT_MAC_ADDRESS: 183,
+  INTERFACE: 187,
 
   /* events */
   EVENT_SET_VALUE: 184,
@@ -846,11 +848,6 @@ export class TnglCompiler {
         this.#tnglWriter.writeFlag(TNGL_FLAGS.INTERACTIVE)
         break
 
-      // === clip ===
-      case 'clip':
-        this.#tnglWriter.writeFlag(TNGL_FLAGS.CLIP)
-        break
-
       // === definitions ===
 
       case 'defController':
@@ -862,20 +859,14 @@ export class TnglCompiler {
       case 'defCanvas':
         this.#tnglWriter.writeFlag(TNGL_FLAGS.DEFINE_CANVAS)
         break
-      case 'defMarks':
-        this.#tnglWriter.writeFlag(TNGL_FLAGS.DEFINE_MARKS)
-        break
       case 'defAnimation':
         this.#tnglWriter.writeFlag(TNGL_FLAGS.DEFINE_ANIMATION)
         break
-      // case "defVariable":
-      //   this.#tnglWriter.writeFlag(TNGL_FLAGS.DECLARE_VARIABLE);
-      //   break;
+      case 'defInterface':
+        this.#tnglWriter.writeFlag(TNGL_FLAGS.DEFINE_INTERFACE)
+        break
 
       // === sifters ===
-      // case "siftDevices":
-      //   this.#tnglWriter.writeFlag(TNGL_FLAGS.SIFTER_CONTROLLER);
-      //   break;
       case 'siftControllers':
         this.#tnglWriter.writeFlag(TNGL_FLAGS.SIFTER_CONTROLLER)
         break
@@ -884,6 +875,11 @@ export class TnglCompiler {
         break
       case 'siftCanvases':
         this.#tnglWriter.writeFlag(TNGL_FLAGS.SIFTER_CANVAS)
+        break
+
+      // === interface implementation ===
+      case 'idScope':
+        this.#tnglWriter.writeFlag(TNGL_FLAGS.SCOPE_ID)
         break
 
       // === objects ===
@@ -899,8 +895,11 @@ export class TnglCompiler {
       case 'canvas':
         this.#tnglWriter.writeFlag(TNGL_FLAGS.CANVAS)
         break
-      case 'marks':
-        this.#tnglWriter.writeFlag(TNGL_FLAGS.MARKS)
+      case 'interface':
+        this.#tnglWriter.writeFlag(TNGL_FLAGS.INTERFACE)
+        break
+      case 'eventstate':
+        this.#tnglWriter.writeFlag(TNGL_FLAGS.EVENTSTATE)
         break
 
       // === modifiers ===
@@ -996,11 +995,14 @@ export class TnglCompiler {
       case 'divValues':
         this.#tnglWriter.writeFlag(TNGL_FLAGS.OPERATION_DIV)
         break
+      case 'nvlValues':
+        this.#tnglWriter.writeFlag(TNGL_FLAGS.OPERATION_NVL)
+        break
       case 'modValues':
         this.#tnglWriter.writeFlag(TNGL_FLAGS.OPERATION_MOD)
         break
       case 'scaValue':
-        this.#tnglWriter.writeFlag(TNGL_FLAGS.OPERATION_SCALE)
+        this.#tnglWriter.writeFlag(TNGL_FLAGS.OPERATION_SCA)
         break
       case 'mapValue':
         this.#tnglWriter.writeFlag(TNGL_FLAGS.OPERATION_MAP)

--- a/SpectodaParser.js
+++ b/SpectodaParser.js
@@ -1134,9 +1134,16 @@ export class TnglCompiler {
     // TODO: Get bytes in WASM and then only send Berry bytecode
 
     // BERRY(`...`)
-    let code = berry.slice(7, -2)
+    const berryMatch = berry.match(/^BERRY\s*\(\s*`([\s\S]*)`\s*\)$/);
+    if (!berryMatch) {
+      logging.error('Invalid Berry script format! Expected BERRY(`...`). Received:', berry);
+      return;
+    }
+    const code = berryMatch[1];
+    logging.info('Berry script:', code);
 
-    const bytes = new TextEncoder().encode(code)
+    const bytes = new TextEncoder().encode(code);
+    logging.info('Berry script bytes:', bytes);
 
     this.#tnglWriter.writeFlag(TNGL_FLAGS.BERRY_SCRIPT)
     this.#tnglWriter.writeUint16(bytes.length)

--- a/SpectodaParser.js
+++ b/SpectodaParser.js
@@ -918,15 +918,17 @@ export class TnglCompiler {
         break
 
       // === events ===
-      case 'catchEvent':
-        this.#tnglWriter.writeFlag(TNGL_FLAGS.EVENT_CATCHER)
-        break
+      case 'catchEvent': // ! deprecate in 0.13
+      case 'onEventStateSet':
+        this.#tnglWriter.writeFlag(TNGL_FLAGS.EVENT_CATCHER);
+        break;
       case 'setValue':
-        this.#tnglWriter.writeFlag(TNGL_FLAGS.EVENT_SET_VALUE)
-        break
-      case 'emitAs':
-        this.#tnglWriter.writeFlag(TNGL_FLAGS.EVENT_EMIT_LOCAL)
-        break
+        this.#tnglWriter.writeFlag(TNGL_FLAGS.EVENT_SET_VALUE);
+        break;
+      case 'emitAs': // ! deprecate in 0.13
+      case 'setEventState':
+        this.#tnglWriter.writeFlag(TNGL_FLAGS.EVENT_EMIT_LOCAL);
+        break;
       case 'randomChoice':
         this.#tnglWriter.writeFlag(TNGL_FLAGS.EVENT_RANDOM_CHOICE)
         break

--- a/SpectodaParser.js
+++ b/SpectodaParser.js
@@ -816,8 +816,11 @@ export class TnglCompiler {
         this.#tnglWriter.writeFlag(TNGL_FLAGS.ANIMATION_COLOR_GRADIENT4)
         break
       case 'animColorGradient5':
-        this.#tnglWriter.writeFlag(TNGL_FLAGS.ANIMATION_COLOR_GRADIENT5)
-        break
+        this.#tnglWriter.writeFlag(TNGL_FLAGS.ANIMATION_COLOR_GRADIENT5);
+        break;
+      case 'animStream':
+        this.#tnglWriter.writeFlag(TNGL_FLAGS.ANIMATION_STREAM);
+        break;
 
       case 'applyReorder':
         this.#tnglWriter.writeFlag(TNGL_FLAGS.MUTATOR_REORDER)

--- a/src/SpectodaWasm.ts
+++ b/src/SpectodaWasm.ts
@@ -4,7 +4,7 @@ import { logging } from '../logging'
 
 import { MainModule, Uint8Vector } from './types/wasm'
 
-const WASM_VERSION = 'DEBUG_DEV_0.12.5_20250213'
+const WASM_VERSION = 'DEBUG_DEV_0.12.6_20250326'
 
 let moduleInitilizing = false
 let moduleInitilized = false

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,20 @@
 import { SpectodaTypes } from '../types/primitives'
 
-/** @deprecated use `VALUE_TYPE` from `spectoda-js/constants/values` instead. */
+/**
+ * Value type constants for reference
+ *
+ *  0 => UNDEFINED         -> undefined
+ *  1 => NULL              -> null
+ *  2 => BOOLEAN           -> true / false
+ * 19 => PIXELS            -> unit: px, integer only (e.g. 42.2 => 42px)
+ * 26 => COLOR             -> "rrggbb" / "#rrggbb" (lowercased, "#" optional)
+ * 28 => DATE              -> "YYYY-MM-DD"  (left as-is)
+ * 29 => NUMBER            -> generic number, integer only (e.g. 123.45 => 123)
+ * 30 => PERCENTAGE        -> unit: %, allows floating points (e.g. -20.34 => -20.34%)
+ * 31 => LABEL             -> "label" / TODO "$label" (string only, TODO "$" optional)
+ * 32 => TIME              -> unit ms, integer only (e.g. 1234.5 => 1234ms)
+ */
+
 export const VALUE_TYPE = Object.freeze({
   NUMBER: 29,
   LABEL: 31,


### PR DESCRIPTION
This PR brings new TNGL syntax and blockly blocks for creating rules to how EventStates are handled on IDs.

There was a problem that EventState behaviour in TNGL could not be scoped to separate IDs before. That caused issues in creating TNGL templates where there was no mechanism for isolating different EventState controls. 

This is a must for teplated TNGL definition.

This PR also brings new black preprocessor directives blocks #ifdef #if #warning #error and #endif 